### PR TITLE
Fix OrbitControls import path

### DIFF
--- a/src/core/managers/CameraManager.js
+++ b/src/core/managers/CameraManager.js
@@ -1,5 +1,5 @@
 import { CinematicCamera } from '../components/cameras/CinematicCamera';
-import { OrbitControls } from '../components/cameras/controls/OrbitControls';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 export class CameraManager {
     constructor(renderer, container) {


### PR DESCRIPTION
## Summary
- fix `OrbitControls` import path in CameraManager

## Testing
- `npm install`
- `npm run lint` *(fails: 18 errors)*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68585b7b3ed083209b110f64818528ea