### PR TITLE
Move build config to top-level

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -55,10 +55,10 @@ export default defineConfig({
       overlay: false, // Disable error overlay if needed
       port: 3000,
     },
-    build: {
-      outDir: "dist",
-      assetsDir: "assets",
-      sourcemap: true,
-    },
+  },
+  build: {
+    outDir: "dist",
+    assetsDir: "assets",
+    sourcemap: true,
   },
 });


### PR DESCRIPTION
## Summary
- move `build` out of the `server` block in `vite.config.js`

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npx vite build` *(fails: cannot find rollup optional dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68585c5c601483209b9cd5e266a36082