### PR TITLE
Add PWA icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ lerna-debug.log*
 *.hdr
 *.exr
 *.png
+!public/icons/icon-192x192.png
+!public/icons/icon-512x512.png
 *.jpg
 *.jpeg
 *.mp3

--- a/public/icons/icon-192x192.png
+++ b/public/icons/icon-192x192.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcd2e7c98d6d755236a6858327543cc36f27ef4f9d762c8bc4b4267c10b38ca9
+size 4243

--- a/public/icons/icon-512x512.png
+++ b/public/icons/icon-512x512.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd670651e947c6b9e8ea7e780f7eb5855434b9e3520387de8dace61b910b74f0
+size 4137


### PR DESCRIPTION
## Summary
- unignore icon PNGs
- add 192px and 512px icons for PWA manifest

## Testing
- `npm test` *(fails: cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6858755d2b408320a13307713a3a15c8