### PR TITLE
Add generator class wrappers

### DIFF
--- a/src/core/generators/SceneGenerator.js
+++ b/src/core/generators/SceneGenerator.js
@@ -1,0 +1,46 @@
+import { SceneManager } from '../managers/SceneManager';
+
+/**
+ * Basic wrapper around SceneManager to generate scenes from
+ * configuration objects. This allows scenes to be created and
+ * managed with a simple API while keeping the heavy lifting in
+ * the existing managers.
+ */
+export class SceneGenerator {
+  constructor(renderer) {
+    this.manager = new SceneManager(renderer);
+  }
+
+  /**
+   * Create a new scene using the provided configuration.
+   * @param {string} name - Identifier for the scene.
+   * @param {object} [config={}] - Optional scene configuration.
+   * @returns {THREE.Scene}
+   */
+  create(name, config = {}) {
+    return this.manager.createScene(name, config);
+  }
+
+  /**
+   * Set the active scene for rendering.
+   * @param {string} name
+   */
+  setActive(name) {
+    this.manager.setActiveScene(name);
+  }
+
+  /**
+   * Update the active scene each frame.
+   * @param {number} deltaTime
+   */
+  update(deltaTime) {
+    this.manager.update(deltaTime);
+  }
+
+  /** Dispose all created scenes. */
+  dispose() {
+    this.manager.dispose();
+  }
+}
+
+export default SceneGenerator;

--- a/src/core/generators/StageGenerator.js
+++ b/src/core/generators/StageGenerator.js
@@ -1,0 +1,46 @@
+import { StageManager } from '../managers/StageManager';
+
+/**
+ * Simple generator that delegates stage creation and management
+ * to StageManager. This keeps configuration handling flexible
+ * while exposing a minimal interface for external modules.
+ */
+export class StageGenerator {
+  constructor(renderer, container) {
+    this.manager = new StageManager(renderer, container);
+  }
+
+  /**
+   * Create a new stage using the provided configuration.
+   * Convenience wrapper over StageManager.createStage.
+   *
+   * @param {string} name - Identifier for the stage.
+   * @param {object} [config={}] - Optional stage configuration.
+   * @returns {THREE.Scene}
+   */
+  create(name, config = {}) {
+    return this.manager.createStage(name, config);
+  }
+
+  /** Proxy to StageManager.setActiveStage. */
+  setActive(name) {
+    this.manager.setActiveStage(name);
+  }
+
+  /** Update the active stage each frame. */
+  update(deltaTime) {
+    this.manager.update(deltaTime);
+  }
+
+  /** Resize the underlying renderer and cameras. */
+  resize(width, height) {
+    this.manager.resize(width, height);
+  }
+
+  /** Dispose of all resources created by the generator. */
+  dispose() {
+    this.manager.dispose();
+  }
+}
+
+export default StageGenerator;


### PR DESCRIPTION
## Summary
- implement `SceneGenerator` as a simple wrapper over `SceneManager`
- implement `StageGenerator` as a wrapper over `StageManager`

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68587551f7888320b34017b36f86016e